### PR TITLE
Change name of 'JSON Importer' to include CSV

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3198,7 +3198,7 @@
     },
     {
         "id": "obsidian-import-json",
-        "name": "JSON Importer",
+        "name": "JSON/CSV Importer",
         "author": "farling42",
         "description": "Import a JSON file containing an array of data, creating notes from a Handlebars template file",
         "repo": "farling42/obsidian-import-json"


### PR DESCRIPTION
Change name of 'JSON Importer' to 'JSON/CSV Importer'

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files
  - [ ] `main.js`
  - [ ] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [ ] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [ ] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [ ] My README.md describes the plugin's purpose and provides clear usage instructions.
- [ ] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [ ] I have added a license in the LICENSE file.
- [ ] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
